### PR TITLE
Fix broken pipe error when printing ASCII map

### DIFF
--- a/world_generator.py
+++ b/world_generator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import math
 import random
+import sys
 from typing import Tuple
 
 try:
@@ -96,7 +97,11 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     generator = WorldGenerator(args.width, args.height, args.seed, args.scale)
     if args.mode == "ascii":
-        print(generator.ascii_map())
+        try:
+            sys.stdout.write(generator.ascii_map() + "\n")
+        except BrokenPipeError:
+            # stdout was closed (e.g. piped command like `head`)
+            pass
     else:
         generator.save_image(args.output)
         print(f"Saved image to {args.output}")


### PR DESCRIPTION
## Summary
- handle BrokenPipeError when printing ASCII map so piping output works

## Testing
- `python world_generator.py ascii --width 100 --height 100 | head -n 1`
- `python -m py_compile world_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c2885418832ba9792608abc037d3