### PR TITLE
Add diverse terrain features and auto terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Python tool to generate colorful world maps. The maps can be produced as
 ANSI colored ASCII text in the style of Dwarf Fortress or saved as a PNG image.
+The ASCII output now includes features such as deserts, rivers, volcanoes,
+roads and cities using extended characters for extra flair.
 
 ## Requirements
 
@@ -15,8 +17,13 @@ pip install noise Pillow
 
 ## Usage
 
-Generate an ASCII world map:
+Generate an ASCII world map (defaults to your terminal size when width and
+height are not specified):
 
+```bash
+python world_generator.py ascii
+```
+You can still specify `--width` and `--height` if desired:
 ```bash
 python world_generator.py ascii --width 80 --height 40
 ```


### PR DESCRIPTION
## Summary
- expand ASCII map with deserts, rivers, volcanoes, cities, and roads
- support extended characters for richer visuals
- default map size to the current terminal when no dimensions are given
- document new behavior and features

## Testing
- `python -m py_compile world_generator.py`
- `python world_generator.py ascii | head -n 5`
- `python world_generator.py ascii --width 30 --height 10 | head -n 10`


------
https://chatgpt.com/codex/tasks/task_e_6840c3e95910832b8834dce464af875c